### PR TITLE
fix(x-platform): normalise paths to support windows usage

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -77,11 +77,11 @@ if (program.start) {
 
 // Run the build...
 if (program.build) {
-  exec('./node_modules/.bin/eslint src/ && ./node_modules/.bin/rimraf dist', {
+  exec(`${path.normalize('./node_modules/.bin/eslint')} ${path.normalize('src/')} && ${path.normalize('./node_modules/.bin/rimraf')} dist`, {
     stdio: 'inherit',
   });
   console.log('Build config:', program.config);
-  exec('NODE_ENV=production node --max_old_space_size=4096 ./node_modules/.bin/webpack --config ' + program.config, {
+  exec(`NODE_ENV=production node --max_old_space_size=4096 ${path.normalize('./node_modules/.bin/webpack')} --config ` + program.config, {
     stdio: 'inherit',
     env: env,
   });


### PR DESCRIPTION
Using `/` as a file path delimiter prevents the build command
from running on Windows, as Windows uses `\` as a file path delimiter.

File paths have been processed with `path.normalize` to ensure the
correct delimiter is used on each operating system.

https://shapeshed.com/writing-cross-platform-node/#use-pathnormalize-to-create-reliable-paths