### PR TITLE
change path to webpack script

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -81,7 +81,9 @@ if (program.build) {
     stdio: 'inherit',
   });
   console.log('Build config:', program.config);
-  exec(`NODE_ENV=production node --max_old_space_size=4096 ${path.normalize('./node_modules/.bin/webpack')} --config ` + program.config, {
+  const webpackExe = path.normalize('./node_modules/.bin/webpack');
+  const configPath = path.normalize(program.config);
+  exec(`NODE_ENV=production node --max_old_space_size=4096 ${webpackExe} --config ${configPath}`, {
     stdio: 'inherit',
     env: env,
   });

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -81,7 +81,7 @@ if (program.build) {
     stdio: 'inherit',
   });
   console.log('Build config:', program.config);
-  const webpackExe = path.normalize('./node_modules/.bin/webpack');
+  const webpackExe = path.normalize('./node_modules/webpack/bin/webpack');
   const configPath = path.normalize(program.config);
   exec(`NODE_ENV=production node --max_old_space_size=4096 ${webpackExe} --config ${configPath}`, {
     stdio: 'inherit',


### PR DESCRIPTION
I'm attempting to build the [playground](https://github.com/foyerlive/playground) 
project on Windows but have run into an error. 

Running `npm run build` in the Playground project results in: 
```
D:\dev-ie\auspost-kiosk\playground\node_modules\.bin\webpack:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^
SyntaxError: missing ) after argument list
```

The build fails after this error. It appears to be a 
common error on Windows. 

https://github.com/gotwarlost/istanbul/issues/677
https://github.com/facebook/jest/issues/4751

There might be a few potential solutions. 

This blog post suggested changing how Webpack is called. 
https://www.programmersought.com/article/49215661254/

Quote:
> The first type of packaging command is ./node_modules/.bin/webpack, 
> you can see that all the shell commands in the .bin directory are .cmd;
> 
> The second type of packaging command is ./node_modules/webpack/bin/webpack, 
> the last webpack is actually a js file, of course it supports node, 
> which also reflects the flexibility and omnipotence of the js language.