### PR TITLE
fix(environment): support for windows build environment

### DIFF
--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -98,7 +98,7 @@ if (program.packageVariation) {
 if (program.start) {
   console.log('Dev config:', program.devconfig);
   server({
-    config: program.devconfig,
+    config: path.normalize(program.devconfig),
     nextGen: program.nextGen,
   });
 }

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -8,7 +8,8 @@ const exec = require('child_process').execSync;
 
 const startServer = options => {
   if (_.get(options, 'nextGen', false)) {
-    exec('./node_modules/.bin/webpack-dev-server --config ' + options.config, {
+    const serverExe = path.normalize('./node_modules/.bin/webpack-dev-server');
+    exec(`${serverExe} --config ${options.config}`, {
       stdio: 'inherit',
       env: process.env,
     });


### PR DESCRIPTION
This PR updates the `fl-cli --start` command so it can run on Windows. Previously it failed due to the incompatible file path delimiters. The `path.normalize` function changes the file paths to use Windows style delimiters. 

